### PR TITLE
Switch installation to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,24 @@
 
 # Getting Started
 ## Installation
+Install [uv](https://github.com/astral-sh/uv) and create a virtual environment:
 ```
-conda create -n mast3r-slam python=3.11
-conda activate mast3r-slam
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv venv mast3r-slam
+source mast3r-slam/bin/activate
 ```
 Check the system's CUDA version with nvcc
 ```
 nvcc --version
 ```
-Install pytorch with **matching** CUDA version following:
+Install PyTorch with a **matching** CUDA version using `uv pip`:
 ```
 # CUDA 11.8
-conda install pytorch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1  pytorch-cuda=11.8 -c pytorch -c nvidia
+uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu118
 # CUDA 12.1
-conda install pytorch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 pytorch-cuda=12.1 -c pytorch -c nvidia
+uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu121
 # CUDA 12.4
-conda install pytorch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 pytorch-cuda=12.4 -c pytorch -c nvidia
+uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu124
 ```
 
 Clone the repo and install the dependencies.
@@ -45,16 +47,15 @@ Clone the repo and install the dependencies.
 git clone https://github.com/rmurai0610/MASt3R-SLAM.git --recursive
 cd MASt3R-SLAM/
 
-# if you've clone the repo without --recursive run
+# if you've cloned the repo without --recursive run
 # git submodule update --init --recursive
 
-pip install -e thirdparty/mast3r
-pip install -e thirdparty/in3d
-pip install --no-build-isolation -e .
- 
+uv pip install -e thirdparty/mast3r
+uv pip install -e thirdparty/in3d
+uv pip install --no-build-isolation -e .
 
 # Optionally install torchcodec for faster mp4 loading
-pip install torchcodec==0.1
+uv pip install torchcodec==0.1
 ```
 
 Setup the checkpoints for MASt3R and retrieval.  The license for the checkpoints and more information on the datasets used is written [here](https://github.com/naver/mast3r/blob/mast3r_sfm/CHECKPOINTS_NOTICE).
@@ -63,6 +64,11 @@ mkdir -p checkpoints/
 wget https://download.europe.naverlabs.com/ComputerVision/MASt3R/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric.pth -P checkpoints/
 wget https://download.europe.naverlabs.com/ComputerVision/MASt3R/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric_retrieval_trainingfree.pth -P checkpoints/
 wget https://download.europe.naverlabs.com/ComputerVision/MASt3R/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric_retrieval_codebook.pkl -P checkpoints/
+```
+
+Alternatively, the script below automates the setup and checkpoint download (defaults to CUDA 11.8):
+```
+bash scripts/setup_uv.sh [env_dir] [cu118|cu121|cu124]
 ```
 
 ## WSL Users

--- a/scripts/setup_uv.sh
+++ b/scripts/setup_uv.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+ENV_DIR=${1:-mast3r-slam}
+CUDA_VERSION=${2:-cu118}
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required but not installed. Visit https://astral.sh/uv to install."
+  exit 1
+fi
+
+uv venv "$ENV_DIR"
+source "$ENV_DIR/bin/activate"
+
+uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
+uv pip install -e thirdparty/mast3r
+uv pip install -e thirdparty/in3d
+uv pip install --no-build-isolation -e .
+
+# Uncomment for faster mp4 loading
+# uv pip install torchcodec==0.1
+
+mkdir -p checkpoints
+wget https://download.europe.naverlabs.com/ComputerVision/MASt3R/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric.pth -P checkpoints/
+wget https://download.europe.naverlabs.com/ComputerVision/MASt3R/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric_retrieval_trainingfree.pth -P checkpoints/
+wget https://download.europe.naverlabs.com/ComputerVision/MASt3R/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric_retrieval_codebook.pkl -P checkpoints/


### PR DESCRIPTION
## Summary
- replace conda-based instructions with uv virtualenv and installation steps
- provide setup_uv.sh script to install dependencies and download MASt3R checkpoints using uv

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash scripts/setup_uv.sh test-env cu118` *(failed: large downloads, cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_689fd3e9fb788331bd643c76f2ffaa34