### PR TITLE
Add device-agnostic device selection and timing

### DIFF
--- a/mast3r_slam/frame.py
+++ b/mast3r_slam/frame.py
@@ -108,7 +108,8 @@ class Frame:
         return self.C / self.N if self.C is not None else None
 
 
-def create_frame(i, img, T_WC, img_size=512, device="cuda:0"):
+def create_frame(i, img, T_WC, img_size=512, device="cpu"):
+    device = torch.device(device)
     img = resize_img(img, img_size)
     rgb = img["img"].to(device=device)
     img_shape = torch.tensor(img["true_shape"], device=device)
@@ -123,7 +124,8 @@ def create_frame(i, img, T_WC, img_size=512, device="cuda:0"):
 
 
 class SharedStates:
-    def __init__(self, manager, h, w, dtype=torch.float32, device="cuda"):
+    def __init__(self, manager, h, w, dtype=torch.float32, device="cpu"):
+        device = torch.device(device)
         self.h, self.w = h, w
         self.dtype = dtype
         self.device = device
@@ -218,7 +220,8 @@ class SharedStates:
 
 
 class SharedKeyframes:
-    def __init__(self, manager, h, w, buffer=512, dtype=torch.float32, device="cuda"):
+    def __init__(self, manager, h, w, buffer=512, dtype=torch.float32, device="cpu"):
+        device = torch.device(device)
         self.lock = manager.RLock()
         self.n_size = manager.Value("i", 0)
 

--- a/mast3r_slam/global_opt.py
+++ b/mast3r_slam/global_opt.py
@@ -10,7 +10,8 @@ import mast3r_slam_backends
 
 
 class FactorGraph:
-    def __init__(self, model, frames: SharedKeyframes, K=None, device="cuda"):
+    def __init__(self, model, frames: SharedKeyframes, K=None, device="cpu"):
+        device = torch.device(device)
         self.model = model
         self.frames = frames
         self.device = device

--- a/mast3r_slam/mast3r_utils.py
+++ b/mast3r_slam/mast3r_utils.py
@@ -11,7 +11,8 @@ from mast3r_slam.config import config
 import mast3r_slam.matching as matching
 
 
-def load_mast3r(path=None, device="cuda"):
+def load_mast3r(path=None, device="cpu"):
+    device = torch.device(device)
     weights_path = (
         "checkpoints/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric.pth"
         if path is None
@@ -21,7 +22,8 @@ def load_mast3r(path=None, device="cuda"):
     return model
 
 
-def load_retriever(mast3r_model, retriever_path=None, device="cuda"):
+def load_retriever(mast3r_model, retriever_path=None, device="cpu"):
+    device = torch.device(device)
     retriever_path = (
         "checkpoints/MASt3R_ViTLarge_BaseDecoder_512_catmlpdpt_metric_retrieval_trainingfree.pth"
         if retriever_path is None
@@ -34,7 +36,7 @@ def load_retriever(mast3r_model, retriever_path=None, device="cuda"):
 @torch.inference_mode
 def decoder(model, feat1, feat2, pos1, pos2, shape1, shape2):
     dec1, dec2 = model._decoder(feat1, pos1, feat2, pos2)
-    with torch.amp.autocast(enabled=False, device_type="cuda"):
+    with torch.autocast(device_type=feat1.device.type, enabled=False):
         res1 = model._downstream_head(1, [tok.float() for tok in dec1], shape1)
         res2 = model._downstream_head(2, [tok.float() for tok in dec2], shape2)
     return res1, res2

--- a/mast3r_slam/retrieval_database.py
+++ b/mast3r_slam/retrieval_database.py
@@ -7,7 +7,8 @@ from asmk import io_helpers
 
 
 class RetrievalDatabase(Retriever):
-    def __init__(self, modelname, backbone=None, device="cuda"):
+    def __init__(self, modelname, backbone=None, device="cpu"):
+        device = torch.device(device)
         super().__init__(modelname, backbone, device)
 
         self.ivf_builder = self.asmk.create_ivf_builder()

--- a/mast3r_slam/tictoc.py
+++ b/mast3r_slam/tictoc.py
@@ -1,26 +1,27 @@
+import time
 import torch
 
 
 class Timer:
     """
-    Simple timer which takes forces cuda synchronization.
+    Simple timer with optional device synchronization.
     """
 
     def __init__(self):
         self.timers_start = []
 
     def start(self):
-        start_t = torch.cuda.Event(enable_timing=True)
-        start_t.record()
-        self.timers_start.append(start_t)
+        self.timers_start.append(time.perf_counter())
 
     def stop(self, tag=None):
-        end_t = torch.cuda.Event(enable_timing=True)
-        end_t.record()
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+            torch.mps.synchronize()
+        end_t = time.perf_counter()
         start_t = self.timers_start.pop()
         tag = f"{tag}: " if tag else ""
-        elapsed_time_s = start_t.elapsed_time(end_t) / 1000
+        elapsed_time_s = end_t - start_t
         print(f"{tag}Elapsed {elapsed_time_s}s")
         return elapsed_time_s
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "MAST3R-SLAM"
 version = "0.0.1"
 dependencies = [
-    "numpy==1.26.4",
+    "numpy>=1.26.4",
+    "asmk",
+    "scipy",
     "einops",
     "pyrealsense2",
     "evo",


### PR DESCRIPTION
## Summary
- Detect CUDA, MPS, or CPU at runtime and pass the chosen device through the pipeline
- Allow keyframe/state helpers, retrieval, and optimization modules to receive explicit device arguments
- Replace CUDA-specific autocast and timing utilities with device-aware versions
- Include retrieval dependencies so tests can run without missing modules

## Testing
- `python -m py_compile main.py mast3r_slam/frame.py mast3r_slam/retrieval_database.py mast3r_slam/mast3r_utils.py mast3r_slam/global_opt.py mast3r_slam/tictoc.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a233eb68bc8331bfc9052e1c030b92